### PR TITLE
Tidy up `AccountProvider`

### DIFF
--- a/src/components/AccountSelect.tsx
+++ b/src/components/AccountSelect.tsx
@@ -9,7 +9,7 @@ export const AccountSelect = () => {
 
   return (
     <Section title={`Account: ${selectedAccount?.name || 'None'}`}>
-      {accounts?.map(item => (
+      {accounts.map(item => (
         <Button
           disabled={item === selectedAccount}
           key={item.id}


### PR DESCRIPTION
* Removed `account` property that's not used
* Employed memoization to make sure that the provider doesn't rerender its children too aggressively
* Fixed auto-selecting the first account